### PR TITLE
Arreglos de pestaña de Jobs en Ubiquo

### DIFF
--- a/app/controllers/ubiquo/jobs_controller.rb
+++ b/app/controllers/ubiquo/jobs_controller.rb
@@ -25,7 +25,7 @@ class Ubiquo::JobsController < UbiquoController
       format.xml  { head :ok }
     end
   end
-  
+
   # PUT /jobs/1
   # PUT /jobs/1.xml
   def update
@@ -45,7 +45,7 @@ class Ubiquo::JobsController < UbiquoController
   end
 
   # PUT /jobs/1/repeat
-  def repeat    
+  def repeat
     UbiquoJobs.manager.repeat(params[:id])
     respond_to do |format|
       flash[:notice] = t("ubiquo.jobs.job_repeated")
@@ -62,13 +62,13 @@ class Ubiquo::JobsController < UbiquoController
   end
 
   private
-  
+
   def generic_index(finished)
     respond_to do |format|
       format.html {
         order_by = params[:order_by] || 'id'
         sort_order = params[:sort_order] || 'desc'
-        
+
         filters = {
           :text => params[:filter_text],
           :date_start => params[:filter_date_start],
@@ -76,14 +76,15 @@ class Ubiquo::JobsController < UbiquoController
           :state => (UbiquoJobs::Jobs::Base::STATES[:finished] if finished),
           :state_not => (UbiquoJobs::Jobs::Base::STATES[:finished] unless finished),
           :page => params[:page],
-          :order => "#{order_by.gsub(/^.*\./, '')} #{sort_order}"
+          :order => "#{order_by.gsub(/^.*\./, '')} #{sort_order}",
+          :per_page => 20
         }
-        @jobs_pages, @jobs = UbiquoJobs.manager.list(filters) 
+        @jobs_pages, @jobs = UbiquoJobs.manager.list(filters)
       } # index.html.erb or history.html.erb
       format.xml  {
         @jobs = UbiquoJobs.manager.list
         render :xml => @jobs
       }
-    end    
+    end
   end
 end

--- a/app/controllers/ubiquo/jobs_controller.rb
+++ b/app/controllers/ubiquo/jobs_controller.rb
@@ -2,6 +2,9 @@ class Ubiquo::JobsController < UbiquoController
   # GET /jobs
   # GET /jobs.xml
   def index
+    params[:sort_order] = 'desc' unless params[:sort_order]
+    params[:order_by] = 'id' unless params[:order_by]
+
     generic_index(false)
   end
 

--- a/app/controllers/ubiquo/jobs_controller.rb
+++ b/app/controllers/ubiquo/jobs_controller.rb
@@ -4,6 +4,7 @@ class Ubiquo::JobsController < UbiquoController
   def index
     params[:sort_order] = 'desc' unless params[:sort_order]
     params[:order_by] = 'id' unless params[:order_by]
+    params[:per_page] = 20 unless params[:per_page]
 
     generic_index(false)
   end
@@ -76,12 +77,21 @@ class Ubiquo::JobsController < UbiquoController
           :text => params[:filter_text],
           :date_start => params[:filter_date_start],
           :date_end => params[:filter_date_end],
-          :state => (UbiquoJobs::Jobs::Base::STATES[:finished] if finished),
-          :state_not => (UbiquoJobs::Jobs::Base::STATES[:finished] unless finished),
           :page => params[:page],
           :order => "#{order_by.gsub(/^.*\./, '')} #{sort_order}",
-          :per_page => 20
         }
+
+        state_filters = {
+          :state => (UbiquoJobs::Jobs::Base::STATES[:finished] if finished),
+          :state_not => (UbiquoJobs::Jobs::Base::STATES[:finished] unless finished)
+        }
+
+        if params[:filter_state].blank?
+          filters = filters.merge(state_filters)
+        else
+          filters[:state] = params[:filter_state]
+        end
+
         @jobs_pages, @jobs = UbiquoJobs.manager.list(filters)
       } # index.html.erb or history.html.erb
       format.xml  {

--- a/app/controllers/ubiquo/jobs_controller.rb
+++ b/app/controllers/ubiquo/jobs_controller.rb
@@ -78,7 +78,10 @@ class Ubiquo::JobsController < UbiquoController
           :date_start => params[:filter_date_start],
           :date_end => params[:filter_date_end],
           :page => params[:page],
+          :planified_at_start => params[:filter_planified_at_start],
+          :planified_at_end => params[:filter_planified_at_end],
           :order => "#{order_by.gsub(/^.*\./, '')} #{sort_order}",
+          :per_page => params[:per_page]
         }
 
         state_filters = {

--- a/app/helpers/ubiquo/jobs_helper.rb
+++ b/app/helpers/ubiquo/jobs_helper.rb
@@ -7,6 +7,10 @@ module Ubiquo::JobsHelper
         :field   => [:filter_date_start, :filter_date_end],
         :caption => t('ubiquo.jobs.creation_date')
       )
+      f.date(
+        :field   => [:planified_at_start, :planified_at_end],
+        :caption => t('ubiquo.jobs.planified_at')
+      )
       Struct.new("FilterState", :state, :id)
       states = UbiquoJobs::Jobs::Base::STATES.to_a.map do |name, id|
         Struct::FilterState.new(state_name(id), id) if name != :finished

--- a/app/helpers/ubiquo/jobs_helper.rb
+++ b/app/helpers/ubiquo/jobs_helper.rb
@@ -7,6 +7,9 @@ module Ubiquo::JobsHelper
         :field   => [:filter_date_start, :filter_date_end],
         :caption => t('ubiquo.jobs.creation_date')
       )
+      Struct.new("FilterState", :state, :id)
+      states = UbiquoJobs::Jobs::Base::STATES.to_a.map { |state| Struct::FilterState.new(*state) }
+      f.select :state, states, :name_field => 'state'
     end
   end
 

--- a/app/helpers/ubiquo/jobs_helper.rb
+++ b/app/helpers/ubiquo/jobs_helper.rb
@@ -8,8 +8,10 @@ module Ubiquo::JobsHelper
         :caption => t('ubiquo.jobs.creation_date')
       )
       Struct.new("FilterState", :state, :id)
-      states = UbiquoJobs::Jobs::Base::STATES.to_a.map { |state| Struct::FilterState.new(*state) }
-      f.select :state, states, :name_field => 'state'
+      states = UbiquoJobs::Jobs::Base::STATES.to_a.map do |name, id|
+        Struct::FilterState.new(state_name(id), id) if name != :finished
+      end
+      f.select :state, states.compact, :name_field => 'state'
     end
   end
 

--- a/lib/ubiquo_jobs/jobs/active_job.rb
+++ b/lib/ubiquo_jobs/jobs/active_job.rb
@@ -46,7 +46,6 @@ module UbiquoJobs
       # Ubiquo finder method
       # See vendor/plugins/ubiquo_core/lib/extensions/active_record.rb to see an example of usage.
       def self.filtered_search(filters = {}, options = {})
-
         scopes = create_scopes(filters) do |filter, value|
           case filter
           when :text
@@ -66,6 +65,8 @@ module UbiquoJobs
           find(:all, options)
         end
       end
+
+      class << self; alias_method :job_filtered_search, :filtered_search; end
 
       # Set a job to be executed (again), giving it a planification time
       # Useful e.g. for a stopped job or a job that has not had a succesful

--- a/lib/ubiquo_jobs/jobs/active_job.rb
+++ b/lib/ubiquo_jobs/jobs/active_job.rb
@@ -51,24 +51,22 @@ module UbiquoJobs
           when :text
             {:conditions => ["upper(name) LIKE upper(?)", "%#{value}%"]}
           when :date_start
-            {:conditions => ["created_at > ?", "#{value}"]}
+            {:conditions => ["created_at > ?", CalendarDateSelect.parse_only_date(value)] }
           when :date_end
-            {:conditions => ["created_at < ?", "#{value}"]}
+            {:conditions => ["created_at < ?", CalendarDateSelect.parse_only_date(value)] }
           when :state
             {:conditions => ["state = ?", value]}
           when :state_not
             {:conditions => ["state != ?", value]}
           when :planified_at_start
-            {:conditions => ["planified_at BETWEEN ? AND ?", value, filters[:planified_at_end]]}
+            {:conditions => ["planified_at > ?", CalendarDateSelect.parse_only_date(value)] }
+          when :planified_at_end
+            {:conditions => ["planified_at < ?", CalendarDateSelect.parse_only_date(value)] }
           end
         end
 
-        apply_find_scopes(scopes) do
-          find(:all, options)
-        end
+        apply_find_scopes(scopes) do find(:all, options) end
       end
-
-      class << self; alias_method :job_filtered_search, :filtered_search; end
 
       # Set a job to be executed (again), giving it a planification time
       # Useful e.g. for a stopped job or a job that has not had a succesful

--- a/lib/ubiquo_jobs/jobs/active_job.rb
+++ b/lib/ubiquo_jobs/jobs/active_job.rb
@@ -58,6 +58,8 @@ module UbiquoJobs
             {:conditions => ["state = ?", value]}
           when :state_not
             {:conditions => ["state != ?", value]}
+          when :planified_at_start
+            {:conditions => ["planified_at BETWEEN ? AND ?", value, filters[:planified_at_end]]}
           end
         end
 


### PR DESCRIPTION
Parte de https://github.com/taigabe/gara-web/issues/622

En esta tarea se arregla:
- Botón de quitar filtros
- Añadir filtros nuevos (fecha de planificación y estado) (junto con PR en gara-web)
- Que los filtros funcionen (junto con PR en ubiquo_core)
- Mostrar 20 resultados por página

Especial atención al último punto. Ver texto del commit _91b6957_. No es una solución idónea a mi gusto, pero es suficiente. Queda abierto a más opiniones el modo de hacerlo.

Esta pull request depende de otras dos:
- ubiquo_core -> https://github.com/taigabe/ubiquo_core/pull/3
- gara-web -> https://github.com/taigabe/gara-web/pull/635